### PR TITLE
Adventure avatars

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,0 +1,14 @@
+[
+{
+    "id": "Adventurer",
+    "name": "Adventurer avatars",
+    "version": "1.0",
+    "description": "A plugin for Adventurer by Lisa Wischofsky profile avatars using DiceBear.",
+    "author": {
+        "name": "Bethropolis",
+        "url": "https://bethropolis.github.io" 
+    },
+    "github": "https://github.com/bethropolis/suplike-adventurer-avatars-plugin"
+    "install_url": "https://github.com/bethropolis/suplike-adventurer-avatars-plugin/releases/download/1.0.0/avatars.zip"
+}
+]


### PR DESCRIPTION
# suplike Adventurer avatars plugin


A plugin for [Adventurer](https://www.figma.com/community/file/1184595184137881796) by [Lisa Wischofsky](https://www.instagram.com/lischi_art/) profile avatars using [DiceBear](https://www.dicebear.com/styles/adventurer). for [suplike social network](https://github.com/bethropolis/suplike-social-website)


App: [suplike social network](https://github.com/bethropolis/suplike-social-website)

plugin system: [bethropolis/plugin-system](https://github.com/bethropolis/plugin-system)



Projects license: [MIT](LICENSE)

Adveturer's Licence:[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)